### PR TITLE
fix: add missing watchers

### DIFF
--- a/internal/controller/k8s/v1alpha1/daemonset.go
+++ b/internal/controller/k8s/v1alpha1/daemonset.go
@@ -45,7 +45,10 @@ func NewDaemonSetReconciler(
 	return &DaemonSetReconciler{
 		Name: "DaemonSetReconciler",
 		Setup: func(ctx context.Context, _ ctrl.Manager, builder *builder.Builder) error {
+			builder.Watches(new(apiv1alpha1.Static), reconcilers.EnqueueTracked(ctx))
 			builder.Watches(new(k8sv1alpha1.DaemonSet), reconcilers.EnqueueTracked(ctx))
+			builder.Watches(new(k8sv1alpha1.Deployment), reconcilers.EnqueueTracked(ctx))
+			builder.Watches(new(k8sv1alpha1.StatefulSet), reconcilers.EnqueueTracked(ctx))
 			return nil
 		},
 		Config: *config,

--- a/internal/controller/k8s/v1alpha1/deployment.go
+++ b/internal/controller/k8s/v1alpha1/deployment.go
@@ -45,7 +45,10 @@ func NewDeploymentReconciler(
 	return &DeploymentReconciler{
 		Name: "DeploymentReconciler",
 		Setup: func(ctx context.Context, _ ctrl.Manager, builder *builder.Builder) error {
+			builder.Watches(new(apiv1alpha1.Static), reconcilers.EnqueueTracked(ctx))
+			builder.Watches(new(k8sv1alpha1.DaemonSet), reconcilers.EnqueueTracked(ctx))
 			builder.Watches(new(k8sv1alpha1.Deployment), reconcilers.EnqueueTracked(ctx))
+			builder.Watches(new(k8sv1alpha1.StatefulSet), reconcilers.EnqueueTracked(ctx))
 			return nil
 		},
 		Config: *config,

--- a/internal/controller/k8s/v1alpha1/statefulset.go
+++ b/internal/controller/k8s/v1alpha1/statefulset.go
@@ -46,6 +46,9 @@ func NewStatefulSetReconciler(
 		Name:   "StatefulSetReconciler",
 		Config: *config,
 		Setup: func(ctx context.Context, _ ctrl.Manager, builder *builder.Builder) error {
+			builder.Watches(new(apiv1alpha1.Static), reconcilers.EnqueueTracked(ctx))
+			builder.Watches(new(k8sv1alpha1.DaemonSet), reconcilers.EnqueueTracked(ctx))
+			builder.Watches(new(k8sv1alpha1.Deployment), reconcilers.EnqueueTracked(ctx))
 			builder.Watches(new(k8sv1alpha1.StatefulSet), reconcilers.EnqueueTracked(ctx))
 			return nil
 		},

--- a/internal/controller/v1alpha1/static.go
+++ b/internal/controller/v1alpha1/static.go
@@ -26,6 +26,7 @@ import (
 
 	"reconciler.io/runtime/reconcilers"
 
+	k8sv1alpha1 "github.com/fastforgeinc/tensegrity/api/k8s/v1alpha1"
 	apiv1alpha1 "github.com/fastforgeinc/tensegrity/api/v1alpha1"
 )
 
@@ -39,6 +40,9 @@ func NewStaticReconciler(
 		Name: "StaticReconciler",
 		Setup: func(ctx context.Context, _ ctrl.Manager, builder *builder.Builder) error {
 			builder.Watches(new(apiv1alpha1.Static), reconcilers.EnqueueTracked(ctx))
+			builder.Watches(new(k8sv1alpha1.DaemonSet), reconcilers.EnqueueTracked(ctx))
+			builder.Watches(new(k8sv1alpha1.Deployment), reconcilers.EnqueueTracked(ctx))
+			builder.Watches(new(k8sv1alpha1.StatefulSet), reconcilers.EnqueueTracked(ctx))
 			return nil
 		},
 		Config: *config,


### PR DESCRIPTION
The PR adds watchers for the Tensegrity resources to track key/value changes and initiate related reconciliations

Fixes: #3 